### PR TITLE
Homebrew Cleanup

### DIFF
--- a/installers/homebrew.sh
+++ b/installers/homebrew.sh
@@ -37,8 +37,5 @@ brew upgrade
 # Install CLI tools & GUI applications
 brew bundle --file=installers/homebrew/Brewfile
 
-# Remove outdated versions from the cellar
+# Remove outdated versions from the cellar including casks
 brew cleanup && brew prune
-
-# Remove outdated cask versions from the cellar
-brew cask cleanup


### PR DESCRIPTION
`brew cask cleanup` has been deprecated in favor of `brew cleanup` and will be disabled on 9.30.2018.
<img width="854" alt="brew-cask-cleanup" src="https://user-images.githubusercontent.com/4745854/46240980-33a76b00-c375-11e8-8b19-387e97705c9c.png">
